### PR TITLE
MessagePack types error fixed by adding more flexible type definitions.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "deno.enable": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Releases
 
+- [0.2.1](#021-2024-08-27) (2024-08-27)
 - [0.2.0](#020-2022-10-11) (2022-10-11)
 - [0.1.1](#011-2022-09-14) (2022-09-14)
 - [0.1.0](#010-2022-09-12) (2022-09-12)
+
+# [0.2.1](https://github.com/itsfuad/socket.io-deno/compare/0.2.0...0.2.1) (2024-08-27)
+
+### Bug Fixes
+
+- **engine:** Add check for readyState before sending packets
 
 # [0.2.0](https://github.com/socketio/socket.io-deno/compare/0.1.1...0.2.0) (2022-10-11)
 

--- a/packages/engine.io/lib/transports/websocket.ts
+++ b/packages/engine.io/lib/transports/websocket.ts
@@ -16,7 +16,7 @@ export class WS extends Transport {
   public send(packets: Packet[]) {
     for (const packet of packets) {
       Parser.encodePacket(packet, true, (data: RawData) => {
-        if (this.writable) {
+        if (this.writable && this.readyState === "open") {
           this.socket?.send(data);
         }
       });

--- a/packages/msgpack/lib/decode.ts
+++ b/packages/msgpack/lib/decode.ts
@@ -44,7 +44,7 @@ function utf8Read(view: DataView, offset: number, length: number) {
 
 class Decoder {
   public _offset = 0;
-  private readonly _buffer: ArrayBuffer;
+  private readonly _buffer: ArrayBuffer | SharedArrayBuffer;
   private readonly _view: DataView;
 
   constructor(buffer: ArrayBuffer | ArrayBufferView) {

--- a/packages/msgpack/lib/encode.ts
+++ b/packages/msgpack/lib/encode.ts
@@ -46,7 +46,7 @@ function utf8Length(str: string) {
 type DeferredElement = {
   _str?: string;
   _float?: number;
-  _bin?: ArrayBuffer;
+  _bin?: ArrayBuffer | ArrayBufferLike;
   _length: number;
   _offset: number;
 };
@@ -60,7 +60,7 @@ function _encodeObject(
     return _encode(bytes, defers, (value.toJSON as unknown as () => unknown)());
   }
 
-  const keys = [];
+  const keys: any[] = [];
   let key: string;
 
   const allKeys = Object.keys(value);

--- a/packages/socket.io/lib/parent-namespace.ts
+++ b/packages/socket.io/lib/parent-namespace.ts
@@ -23,13 +23,6 @@ export class ParentNamespace<
     server: Server<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
   ) {
     super(server, "/_" + ParentNamespace.count++);
-    // this.adapter = {
-    //   broadcast(packet: Packet, opts: BroadcastOptions) {
-    //     this.children.forEach((nsp: Namespace) => {
-    //       nsp.adapter.broadcast(packet, opts);
-    //     });
-    //   }
-    // };
   }
 
   public emit<Ev extends EventNames<EmitEvents>>(

--- a/packages/socket.io/lib/server.ts
+++ b/packages/socket.io/lib/server.ts
@@ -45,9 +45,9 @@ export interface ServerOptions {
 }
 
 export interface ServerReservedEvents<
-  ListenEvents,
-  EmitEvents,
-  ServerSideEvents,
+  ListenEvents extends EventsMap,
+  EmitEvents extends EventsMap,
+  ServerSideEvents extends EventsMap,
   SocketData,
 > extends
   NamespaceReservedEvents<


### PR DESCRIPTION
- encode.ts
On line 70
> Argument of type 'string' is not assignable to parameter of type 'never'.

Fix - change `const keys = [];` to `const keys: any[] = [];` on line 63

On line 328
> Fixed error: Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer | undefined'.
  Property 'resize' is missing in type 'SharedArrayBuffer' but required in type 'ArrayBuffer'.

Fix - change `_bin?: ArrayBuffer;` to `_bin?: ArrayBuffer | ArrayBufferLike;` on like 49



- decode.ts
On line 56
> Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
  Property 'resize' is missing in type 'SharedArrayBuffer' but required in type 'ArrayBuffer'

Fix - change `private readonly _buffer: ArrayBuffer;` to `private readonly _buffer: ArrayBuffer | SharedArrayBuffer;` on line 47.
  
  