### PR TITLE
Bug fix for program crash

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "deno.enable": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Releases
 
+- [0.2.1](#021-2024-08-27) (2024-08-27)
 - [0.2.0](#020-2022-10-11) (2022-10-11)
 - [0.1.1](#011-2022-09-14) (2022-09-14)
 - [0.1.0](#010-2022-09-12) (2022-09-12)
+
+# [0.2.1](https://github.com/itsfuad/socket.io-deno/compare/0.2.0...0.2.1) (2024-08-27)
+
+### Bug Fixes
+
+- **engine:** Add check for readyState before sending packets
 
 # [0.2.0](https://github.com/socketio/socket.io-deno/compare/0.1.1...0.2.0) (2022-10-11)
 

--- a/packages/engine.io/lib/transports/websocket.ts
+++ b/packages/engine.io/lib/transports/websocket.ts
@@ -16,7 +16,7 @@ export class WS extends Transport {
   public send(packets: Packet[]) {
     for (const packet of packets) {
       Parser.encodePacket(packet, true, (data: RawData) => {
-        if (this.writable) {
+        if (this.writable && this.readyState === "open") {
           this.socket?.send(data);
         }
       });

--- a/packages/msgpack/lib/decode.ts
+++ b/packages/msgpack/lib/decode.ts
@@ -44,7 +44,7 @@ function utf8Read(view: DataView, offset: number, length: number) {
 
 class Decoder {
   public _offset = 0;
-  private readonly _buffer: ArrayBuffer;
+  private readonly _buffer: ArrayBuffer | SharedArrayBuffer;
   private readonly _view: DataView;
 
   constructor(buffer: ArrayBuffer | ArrayBufferView) {

--- a/packages/msgpack/lib/encode.ts
+++ b/packages/msgpack/lib/encode.ts
@@ -46,7 +46,7 @@ function utf8Length(str: string) {
 type DeferredElement = {
   _str?: string;
   _float?: number;
-  _bin?: ArrayBuffer;
+  _bin?: ArrayBuffer | ArrayBufferLike;
   _length: number;
   _offset: number;
 };
@@ -60,7 +60,7 @@ function _encodeObject(
     return _encode(bytes, defers, (value.toJSON as unknown as () => unknown)());
   }
 
-  const keys = [];
+  const keys: any[] = [];
   let key: string;
 
   const allKeys = Object.keys(value);

--- a/packages/socket.io/lib/parent-namespace.ts
+++ b/packages/socket.io/lib/parent-namespace.ts
@@ -23,13 +23,6 @@ export class ParentNamespace<
     server: Server<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
   ) {
     super(server, "/_" + ParentNamespace.count++);
-    // this.adapter = {
-    //   broadcast(packet: Packet, opts: BroadcastOptions) {
-    //     this.children.forEach((nsp: Namespace) => {
-    //       nsp.adapter.broadcast(packet, opts);
-    //     });
-    //   }
-    // };
   }
 
   public emit<Ev extends EventNames<EmitEvents>>(

--- a/packages/socket.io/lib/server.ts
+++ b/packages/socket.io/lib/server.ts
@@ -45,9 +45,9 @@ export interface ServerOptions {
 }
 
 export interface ServerReservedEvents<
-  ListenEvents,
-  EmitEvents,
-  ServerSideEvents,
+  ListenEvents extends EventsMap,
+  EmitEvents extends EventsMap,
+  ServerSideEvents extends EventsMap,
   SocketData,
 > extends
   NamespaceReservedEvents<


### PR DESCRIPTION

This pull request includes several improvements and bug fixes across multiple files. The most important changes include enabling Deno in the VSCode settings, updating the changelog with a new release, fixing a bug in the WebSocket transport, and enhancing compatibility in the msgpack library.

### Configuration Updates:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R3): Enabled Deno by setting `"deno.enable": true`.

### Documentation Updates:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R13): Added release notes for version 0.2.1, including a bug fix for the engine.

### Bug Fixes:
* [`packages/engine.io/lib/transports/websocket.ts`](diffhunk://#diff-21ec8f66bbae52f1011069e1de63a91c0ba30c6aa448b9a166f99c9ee7497954L19-R19): Added a check for `readyState` before sending packets in the WebSocket transport.

### Compatibility Enhancements:
* [`packages/msgpack/lib/decode.ts`](diffhunk://#diff-a24c66d82ed32c58502a9d7c15c04ad312783954d1685047d7bdb5457efa17a2L47-R47): Modified the `_buffer` type to accept `ArrayBuffer` or `SharedArrayBuffer`.
* [`packages/msgpack/lib/encode.ts`](diffhunk://#diff-9776d65d2d8c30319073e3f77b8d0453c395895247a8d794e9a33260f22e858bL49-R49): Updated the `_bin` type to accept `ArrayBuffer` or `ArrayBufferLike` and changed `keys` to be of type `any[]`. [[1]](diffhunk://#diff-9776d65d2d8c30319073e3f77b8d0453c395895247a8d794e9a33260f22e858bL49-R49) [[2]](diffhunk://#diff-9776d65d2d8c30319073e3f77b8d0453c395895247a8d794e9a33260f22e858bL63-R63)

### Code Cleanup:
* [`packages/socket.io/lib/parent-namespace.ts`](diffhunk://#diff-ead11da5d025ca3183930707a9f22d4bfaa1e8056f80b2bb1b5f1cd2a97fe03bL26-L32): Removed commented-out adapter code from the `ParentNamespace` class.
* [`packages/socket.io/lib/server.ts`](diffhunk://#diff-a08e353517ae0aaa2aed798612b6cf657c0b7480dce81cf6219512bf94b14168L48-R50): Ensured `ServerReservedEvents` interface types extend `EventsMap`.

### Fixes [Issue](https://github.com/socketio/socket.io-deno/issues/23)