### PR TITLE
Fix namespace reconnect state, Engine.IO transport validation, and handshake metadata

### DIFF
--- a/packages/engine.io/lib/server.ts
+++ b/packages/engine.io/lib/server.ts
@@ -162,14 +162,16 @@ export class Server extends EventEmitter<
     const responseHeaders = new Headers();
     if (this.opts.cors) {
       addCorsHeaders(responseHeaders, this.opts.cors, req);
-
-      if (req.method === "OPTIONS") {
-        return new Response(null, { status: 204, headers: responseHeaders });
-      }
     }
 
     if (this.opts.editResponseHeaders) {
       await this.opts.editResponseHeaders(responseHeaders, req, connInfo);
+    }
+
+    if (this.opts.cors) {
+      if (req.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: responseHeaders });
+      }
     }
 
     try {
@@ -278,20 +280,26 @@ export class Server extends EventEmitter<
         });
       }
       const previousTransport = client.transport.name;
-      if (previousTransport === "websocket") {
+      const isUpgradeRequest = req.headers.has("upgrade");
+      const isValidUpgrade = previousTransport === "polling" &&
+        transport === "websocket" &&
+        isUpgradeRequest;
+
+      if (
+        previousTransport === "websocket" ||
+        (!isValidUpgrade && transport !== previousTransport)
+      ) {
         getLogger("engine.io").debug(
           "[server] unexpected transport without upgrade",
         );
-        return Promise.reject(
-          {
-            code: ERROR_CODES.BAD_REQUEST,
-            context: {
-              name: "TRANSPORT_MISMATCH",
-              transport,
-              previousTransport,
-            },
+        return Promise.reject({
+          code: ERROR_CODES.BAD_REQUEST,
+          context: {
+            name: "TRANSPORT_MISMATCH",
+            transport,
+            previousTransport,
           },
-        );
+        });
       }
     } else {
       // handshake is GET only

--- a/packages/engine.io/test/response_headers.test.ts
+++ b/packages/engine.io/test/response_headers.test.ts
@@ -65,4 +65,34 @@ describe("response headers", () => {
       socket.onopen = done;
     });
   });
+
+  it("should send custom response headers for preflight requests", () => {
+    const engine = new Server({
+      cors: {
+        origin: ["https://example.com"],
+      },
+      editResponseHeaders: (responseHeaders) => {
+        responseHeaders.set("x-test", "123");
+      },
+    });
+
+    return setup(engine, 1, async (port, done) => {
+      const response = await fetch(
+        `http://localhost:${port}/engine.io/?EIO=4&transport=polling`,
+        {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://example.com",
+          },
+        },
+      );
+
+      assertEquals(response.status, 204);
+      assertEquals(response.headers.get("x-test"), "123");
+
+      await response.body?.cancel();
+
+      done();
+    });
+  });
 });

--- a/packages/engine.io/test/verification.test.ts
+++ b/packages/engine.io/test/verification.test.ts
@@ -177,69 +177,61 @@ describe("verification", () => {
   it("should disallow invalid handshake method", () => {
     const engine = new Server();
 
-    return setup(
-      engine,
-      2,
-      async (port, partialDone) => {
-        engine.on("connection_error", (err) => {
-          assertExists(err.req);
-          assertEquals(err.code, 2);
-          assertEquals(err.message, "Bad handshake method");
-          assertEquals(err.context.method, "PUT");
-
-          partialDone();
-        });
-
-        const response = await fetch(
-          `http://localhost:${port}/engine.io/?transport=polling`,
-          {
-            method: "put",
-          },
-        );
-
-        assertEquals(response.status, 400);
-
-        const body = await response.json();
-        assertEquals(body.code, 2);
-        assertEquals(body.message, "Bad handshake method");
+    return setup(engine, 2, async (port, partialDone) => {
+      engine.on("connection_error", (err) => {
+        assertExists(err.req);
+        assertEquals(err.code, 2);
+        assertEquals(err.message, "Bad handshake method");
+        assertEquals(err.context.method, "PUT");
 
         partialDone();
-      },
-    );
+      });
+
+      const response = await fetch(
+        `http://localhost:${port}/engine.io/?transport=polling`,
+        {
+          method: "put",
+        },
+      );
+
+      assertEquals(response.status, 400);
+
+      const body = await response.json();
+      assertEquals(body.code, 2);
+      assertEquals(body.message, "Bad handshake method");
+
+      partialDone();
+    });
   });
 
   it("should disallow unsupported protocol versions", () => {
     const engine = new Server();
 
-    return setup(
-      engine,
-      2,
-      async (port, partialDone) => {
-        engine.on("connection_error", (err) => {
-          assertExists(err.req);
-          assertEquals(err.code, 5);
-          assertEquals(err.message, "Unsupported protocol version");
-          assertEquals(err.context.protocol, 3);
-
-          partialDone();
-        });
-
-        const response = await fetch(
-          `http://localhost:${port}/engine.io/?EIO=3&transport=polling`,
-          {
-            method: "get",
-          },
-        );
-
-        assertEquals(response.status, 400);
-
-        const body = await response.json();
-        assertEquals(body.code, 5);
-        assertEquals(body.message, "Unsupported protocol version");
+    return setup(engine, 2, async (port, partialDone) => {
+      engine.on("connection_error", (err) => {
+        assertExists(err.req);
+        assertEquals(err.code, 5);
+        assertEquals(err.message, "Unsupported protocol version");
+        assertEquals(err.context.protocol, 3);
 
         partialDone();
-      },
-    );
+      });
+
+      const response = await fetch(
+        `http://localhost:${port}/engine.io/?EIO=3&transport=polling`,
+        {
+          method: "get",
+        },
+      );
+
+      assertEquals(response.status, 400);
+
+      const body = await response.json();
+      assertEquals(body.code, 5);
+      assertEquals(body.message, "Unsupported protocol version");
+
+      partialDone();
+    });
   });
 
   it("should disallow invalid transport", () => {
@@ -299,6 +291,62 @@ describe("verification", () => {
 
         socket.onclose = done;
       };
+    });
+  });
+
+  it("should disallow transport mismatch for an existing polling session", () => {
+    const engine = new Server();
+
+    return setup(engine, 2, async (port, partialDone) => {
+      engine.on("connection_error", (err) => {
+        assertExists(err.req);
+        assertEquals(err.code, 3);
+        assertEquals(err.message, "Bad request");
+        assertEquals(err.context.name, "TRANSPORT_MISMATCH");
+        assertEquals(err.context.transport, "websocket");
+        assertEquals(err.context.previousTransport, "polling");
+
+        partialDone();
+      });
+
+      const response = await fetch(
+        `http://localhost:${port}/engine.io/?EIO=4&transport=polling`,
+        {
+          method: "get",
+        },
+      );
+
+      const body = await response.text();
+      const sid = JSON.parse(body.substring(1)).sid;
+
+      let timerId: number | undefined;
+
+      const mismatchResponse = await Promise.race([
+        fetch(
+          `http://localhost:${port}/engine.io/?EIO=4&transport=websocket&sid=${sid}`,
+          {
+            method: "get",
+          },
+        ),
+        new Promise<Response>((_, reject) => {
+          timerId = setTimeout(
+            () => reject(new Error("request timed out")),
+            200,
+          );
+        }),
+      ]);
+
+      if (timerId !== undefined) {
+        clearTimeout(timerId);
+      }
+
+      assertEquals(mismatchResponse.status, 400);
+
+      const mismatchBody = await mismatchResponse.json();
+      assertEquals(mismatchBody.code, 3);
+      assertEquals(mismatchBody.message, "Bad request");
+
+      partialDone();
     });
   });
 });

--- a/packages/socket.io/lib/client.ts
+++ b/packages/socket.io/lib/client.ts
@@ -49,15 +49,7 @@ export class Client<
     this.decoder = decoder;
     this.conn = conn;
 
-    const url = new URL(req.url);
-    this.handshake = {
-      url: url.pathname,
-      headers: req.headers,
-      query: url.searchParams,
-      address: (connInfo.remoteAddr as Deno.NetAddr).hostname,
-      secure: false,
-      xdomain: req.headers.has("origin"),
-    };
+    this.handshake = createHandshakeBase(req, connInfo);
 
     conn.on("message", (data) => this.decoder.add(data));
     conn.on("close", (reason) => this.onclose(reason));
@@ -171,7 +163,7 @@ export class Client<
   _remove(
     socket: Socket<ListenEvents, EmitEvents, ServerSideEvents, SocketData>,
   ): void {
-    this.sockets.delete(socket.id);
+    this.sockets.delete(socket.nsp.name);
   }
 
   private close() {
@@ -234,4 +226,21 @@ export class Client<
       this.conn.send(encodedPacket);
     }
   }
+}
+
+export function createHandshakeBase(
+  req: Request,
+  connInfo: Deno.ServeHandlerInfo,
+): Omit<Handshake, "issued" | "time" | "auth"> {
+  const url = new URL(req.url);
+  const origin = req.headers.get("origin");
+
+  return {
+    url: url.pathname,
+    headers: req.headers,
+    query: url.searchParams,
+    address: (connInfo.remoteAddr as Deno.NetAddr).hostname,
+    secure: url.protocol === "https:",
+    xdomain: origin !== null && origin !== url.origin,
+  };
 }

--- a/packages/socket.io/test/client.test.ts
+++ b/packages/socket.io/test/client.test.ts
@@ -1,0 +1,38 @@
+import { assertEquals, describe, it } from "../../../test_deps.ts";
+import { createHandshakeBase } from "../lib/client.ts";
+
+describe("client handshake metadata", () => {
+  it("should derive secure and cross-domain flags from the request URL and origin", () => {
+    const connInfo = {
+      remoteAddr: {
+        transport: "tcp",
+        hostname: "127.0.0.1",
+        port: 1234,
+      },
+    } as Deno.ServeHandlerInfo;
+
+    const sameOriginHandshake = createHandshakeBase(
+      new Request("https://example.com/socket.io/?EIO=4&transport=polling", {
+        headers: {
+          origin: "https://example.com",
+        },
+      }),
+      connInfo,
+    );
+
+    assertEquals(sameOriginHandshake.secure, true);
+    assertEquals(sameOriginHandshake.xdomain, false);
+
+    const crossOriginHandshake = createHandshakeBase(
+      new Request("https://example.com/socket.io/?EIO=4&transport=polling", {
+        headers: {
+          origin: "https://other.example.com",
+        },
+      }),
+      connInfo,
+    );
+
+    assertEquals(crossOriginHandshake.secure, true);
+    assertEquals(crossOriginHandshake.xdomain, true);
+  });
+});

--- a/packages/socket.io/test/handshake.test.ts
+++ b/packages/socket.io/test/handshake.test.ts
@@ -143,124 +143,156 @@ describe("handshake", () => {
         partialDone();
       },
     );
-  });
 
-  it("should trigger a connection event (custom namespace)", () => {
-    const io = new Server();
+    it("should reconnect to a namespace after a client-side namespace disconnect", () => {
+      const io = new Server();
+      io.of("/custom");
 
-    return setup(
-      io,
-      2,
-      async (port, partialDone) => {
-        io.of("/custom").on("connection", (socket) => {
-          assertExists(socket.id);
+      return setup(
+        io,
+        1,
+        async (port, done) => {
+          const response = await fetch(
+            `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
+            {
+              method: "get",
+            },
+          );
+
+          assertEquals(response.status, 200);
+
+          const sid = await parseSessionID(response);
+
+          await eioPush(port, sid, "40/custom,");
+          const firstConnectBody = await eioPoll(port, sid);
+          assertEquals(firstConnectBody.startsWith("40/custom,{"), true);
+
+          await eioPush(port, sid, "41/custom,");
+
+          await eioPush(port, sid, "40/custom,");
+          const secondConnectBody = await eioPoll(port, sid);
+          assertEquals(secondConnectBody.startsWith("40/custom,{"), true);
+
+          done();
+        });
+    });
+
+    it("should trigger a connection event (custom namespace)", () => {
+      const io = new Server();
+
+      return setup(io,
+        2,
+        async (port, partialDone) => {
+          io.of("/custom").on("connection", (socket) => {
+            assertExists(socket.id);
+            partialDone();
+          });
+
+          const response = await fetch(
+            `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
+            {
+              method: "get",
+            },
+          );
+
+          assertEquals(response.status, 200);
+
+          const sid = await parseSessionID(response);
+
+          await eioPush(port, sid, "40/custom,");
+
+          const body = await eioPoll(port, sid);
+          assertEquals(body.startsWith("40/custom,{"), true);
+
           partialDone();
-        });
+        },
+      );
+    });
 
-        const response = await fetch(
-          `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
-          {
-            method: "get",
-          },
-        );
+    it("should trigger a connection event (dynamic namespace)", () => {
+      const io = new Server();
 
-        assertEquals(response.status, 200);
+      return setup(
+        io,
+        2,
+        async (port, partialDone) => {
+          io.of(/^\/dynamic-\d+$/).on("connection", (socket) => {
+            assertExists(socket.id);
+            partialDone();
+          });
 
-        const sid = await parseSessionID(response);
+          const response = await fetch(
+            `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
+            {
+              method: "get",
+            },
+          );
 
-        await eioPush(port, sid, "40/custom,");
+          assertEquals(response.status, 200);
 
-        const body = await eioPoll(port, sid);
-        assertEquals(body.startsWith("40/custom,{"), true);
+          const sid = await parseSessionID(response);
 
-        partialDone();
-      },
-    );
-  });
+          await eioPush(port, sid, "40/dynamic-101,");
 
-  it("should trigger a connection event (dynamic namespace)", () => {
-    const io = new Server();
+          const body = await eioPoll(port, sid);
+          assertEquals(body.startsWith("40/dynamic-101,{"), true);
 
-    return setup(
-      io,
-      2,
-      async (port, partialDone) => {
-        io.of(/^\/dynamic-\d+$/).on("connection", (socket) => {
-          assertExists(socket.id);
           partialDone();
-        });
+        },
+      );
+    });
 
-        const response = await fetch(
-          `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
-          {
-            method: "get",
-          },
-        );
+    it("should return an error when reaching a non-existent namespace", () => {
+      const io = new Server();
 
-        assertEquals(response.status, 200);
+      return setup(
+        io,
+        1,
+        async (port, done) => {
+          const response = await fetch(
+            `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
+            {
+              method: "get",
+            },
+          );
 
-        const sid = await parseSessionID(response);
+          const sid = await parseSessionID(response);
 
-        await eioPush(port, sid, "40/dynamic-101,");
+          await eioPush(port, sid, "40/unknown,");
 
-        const body = await eioPoll(port, sid);
-        assertEquals(body.startsWith("40/dynamic-101,{"), true);
+          const body = await eioPoll(port, sid);
 
-        partialDone();
-      },
-    );
-  });
+          assertEquals(body, '44/unknown,{"message":"Invalid namespace"}');
 
-  it("should return an error when reaching a non-existent namespace", () => {
-    const io = new Server();
+          done();
+        },
+      );
+    });
 
-    return setup(
-      io,
-      1,
-      async (port, done) => {
-        const response = await fetch(
-          `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
-          {
-            method: "get",
-          },
-        );
+    it("should complete handshake before sending any event", () => {
+      const io = new Server();
 
-        const sid = await parseSessionID(response);
+      return setup(
+        io,
+        1,
+        async (port, done) => {
+          io.use((socket) => {
+            socket.emit("1");
+            io.emit("ignored"); // socket is not connected yet
+            return Promise.resolve();
+          });
 
-        await eioPush(port, sid, "40/unknown,");
+          io.on("connection", (socket) => {
+            socket.emit("2");
+          });
 
-        const body = await eioPoll(port, sid);
+          const [_, firstPacket] = await runHandshake(port);
 
-        assertEquals(body, '44/unknown,{"message":"Invalid namespace"}');
+          assertEquals(firstPacket, '42["1"]\x1e42["2"]');
 
-        done();
-      },
-    );
-  });
-
-  it("should complete handshake before sending any event", () => {
-    const io = new Server();
-
-    return setup(
-      io,
-      1,
-      async (port, done) => {
-        io.use((socket) => {
-          socket.emit("1");
-          io.emit("ignored"); // socket is not connected yet
-          return Promise.resolve();
-        });
-
-        io.on("connection", (socket) => {
-          socket.emit("2");
-        });
-
-        const [_, firstPacket] = await runHandshake(port);
-
-        assertEquals(firstPacket, '42["1"]\x1e42["2"]');
-
-        done();
-      },
-    );
-  });
-});
+          done();
+        },
+      );
+    });
+  })
+})

--- a/packages/socket.io/test/handshake.test.ts
+++ b/packages/socket.io/test/handshake.test.ts
@@ -174,39 +174,37 @@ describe("handshake", () => {
           assertEquals(secondConnectBody.startsWith("40/custom,{"), true);
 
           done();
-        });
+        },
+      );
     });
 
     it("should trigger a connection event (custom namespace)", () => {
       const io = new Server();
 
-      return setup(io,
-        2,
-        async (port, partialDone) => {
-          io.of("/custom").on("connection", (socket) => {
-            assertExists(socket.id);
-            partialDone();
-          });
-
-          const response = await fetch(
-            `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
-            {
-              method: "get",
-            },
-          );
-
-          assertEquals(response.status, 200);
-
-          const sid = await parseSessionID(response);
-
-          await eioPush(port, sid, "40/custom,");
-
-          const body = await eioPoll(port, sid);
-          assertEquals(body.startsWith("40/custom,{"), true);
-
+      return setup(io, 2, async (port, partialDone) => {
+        io.of("/custom").on("connection", (socket) => {
+          assertExists(socket.id);
           partialDone();
-        },
-      );
+        });
+
+        const response = await fetch(
+          `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
+          {
+            method: "get",
+          },
+        );
+
+        assertEquals(response.status, 200);
+
+        const sid = await parseSessionID(response);
+
+        await eioPush(port, sid, "40/custom,");
+
+        const body = await eioPoll(port, sid);
+        assertEquals(body.startsWith("40/custom,{"), true);
+
+        partialDone();
+      });
     });
 
     it("should trigger a connection event (dynamic namespace)", () => {
@@ -294,5 +292,5 @@ describe("handshake", () => {
         },
       );
     });
-  })
-})
+  });
+});

--- a/packages/socket.io/test/handshake.test.ts
+++ b/packages/socket.io/test/handshake.test.ts
@@ -143,46 +143,75 @@ describe("handshake", () => {
         partialDone();
       },
     );
+  });
 
-    it("should reconnect to a namespace after a client-side namespace disconnect", () => {
-      const io = new Server();
-      io.of("/custom");
+  it("should reconnect to a namespace after a client-side namespace disconnect", () => {
+    const io = new Server();
+    io.of("/custom");
 
-      return setup(
-        io,
-        1,
-        async (port, done) => {
-          const response = await fetch(
-            `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
-            {
-              method: "get",
-            },
-          );
-
-          assertEquals(response.status, 200);
-
-          const sid = await parseSessionID(response);
-
-          await eioPush(port, sid, "40/custom,");
-          const firstConnectBody = await eioPoll(port, sid);
-          assertEquals(firstConnectBody.startsWith("40/custom,{"), true);
-
-          await eioPush(port, sid, "41/custom,");
-
-          await eioPush(port, sid, "40/custom,");
-          const secondConnectBody = await eioPoll(port, sid);
-          assertEquals(secondConnectBody.startsWith("40/custom,{"), true);
-
-          done();
+    return setup(io, 1, async (port, done) => {
+      const response = await fetch(
+        `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
+        {
+          method: "get",
         },
       );
+
+      assertEquals(response.status, 200);
+
+      const sid = await parseSessionID(response);
+
+      await eioPush(port, sid, "40/custom,");
+      const firstConnectBody = await eioPoll(port, sid);
+      assertEquals(firstConnectBody.startsWith("40/custom,{"), true);
+
+      await eioPush(port, sid, "41/custom,");
+
+      await eioPush(port, sid, "40/custom,");
+      const secondConnectBody = await eioPoll(port, sid);
+      assertEquals(secondConnectBody.startsWith("40/custom,{"), true);
+
+      done();
     });
+  });
 
-    it("should trigger a connection event (custom namespace)", () => {
-      const io = new Server();
+  it("should trigger a connection event (custom namespace)", () => {
+    const io = new Server();
 
-      return setup(io, 2, async (port, partialDone) => {
-        io.of("/custom").on("connection", (socket) => {
+    return setup(io, 2, async (port, partialDone) => {
+      io.of("/custom").on("connection", (socket) => {
+        assertExists(socket.id);
+        partialDone();
+      });
+
+      const response = await fetch(
+        `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
+        {
+          method: "get",
+        },
+      );
+
+      assertEquals(response.status, 200);
+
+      const sid = await parseSessionID(response);
+
+      await eioPush(port, sid, "40/custom,");
+
+      const body = await eioPoll(port, sid);
+      assertEquals(body.startsWith("40/custom,{"), true);
+
+      partialDone();
+    });
+  });
+
+  it("should trigger a connection event (dynamic namespace)", () => {
+    const io = new Server();
+
+    return setup(
+      io,
+      2,
+      async (port, partialDone) => {
+        io.of(/^\/dynamic-\d+$/).on("connection", (socket) => {
           assertExists(socket.id);
           partialDone();
         });
@@ -198,99 +227,66 @@ describe("handshake", () => {
 
         const sid = await parseSessionID(response);
 
-        await eioPush(port, sid, "40/custom,");
+        await eioPush(port, sid, "40/dynamic-101,");
 
         const body = await eioPoll(port, sid);
-        assertEquals(body.startsWith("40/custom,{"), true);
+        assertEquals(body.startsWith("40/dynamic-101,{"), true);
 
         partialDone();
-      });
-    });
+      },
+    );
+  });
 
-    it("should trigger a connection event (dynamic namespace)", () => {
-      const io = new Server();
+  it("should return an error when reaching a non-existent namespace", () => {
+    const io = new Server();
 
-      return setup(
-        io,
-        2,
-        async (port, partialDone) => {
-          io.of(/^\/dynamic-\d+$/).on("connection", (socket) => {
-            assertExists(socket.id);
-            partialDone();
-          });
+    return setup(
+      io,
+      1,
+      async (port, done) => {
+        const response = await fetch(
+          `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
+          {
+            method: "get",
+          },
+        );
 
-          const response = await fetch(
-            `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
-            {
-              method: "get",
-            },
-          );
+        const sid = await parseSessionID(response);
 
-          assertEquals(response.status, 200);
+        await eioPush(port, sid, "40/unknown,");
 
-          const sid = await parseSessionID(response);
+        const body = await eioPoll(port, sid);
 
-          await eioPush(port, sid, "40/dynamic-101,");
+        assertEquals(body, '44/unknown,{"message":"Invalid namespace"}');
 
-          const body = await eioPoll(port, sid);
-          assertEquals(body.startsWith("40/dynamic-101,{"), true);
+        done();
+      },
+    );
+  });
 
-          partialDone();
-        },
-      );
-    });
+  it("should complete handshake before sending any event", () => {
+    const io = new Server();
 
-    it("should return an error when reaching a non-existent namespace", () => {
-      const io = new Server();
+    return setup(
+      io,
+      1,
+      async (port, done) => {
+        io.use((socket) => {
+          socket.emit("1");
+          io.emit("ignored"); // socket is not connected yet
+          return Promise.resolve();
+        });
 
-      return setup(
-        io,
-        1,
-        async (port, done) => {
-          const response = await fetch(
-            `http://localhost:${port}/socket.io/?EIO=4&transport=polling`,
-            {
-              method: "get",
-            },
-          );
+        io.on("connection", (socket) => {
+          socket.emit("2");
+        });
 
-          const sid = await parseSessionID(response);
+        const [_, firstPacket] = await runHandshake(port);
 
-          await eioPush(port, sid, "40/unknown,");
+        assertEquals(firstPacket, '42["1"]\x1e42["2"]');
 
-          const body = await eioPoll(port, sid);
-
-          assertEquals(body, '44/unknown,{"message":"Invalid namespace"}');
-
-          done();
-        },
-      );
-    });
-
-    it("should complete handshake before sending any event", () => {
-      const io = new Server();
-
-      return setup(
-        io,
-        1,
-        async (port, done) => {
-          io.use((socket) => {
-            socket.emit("1");
-            io.emit("ignored"); // socket is not connected yet
-            return Promise.resolve();
-          });
-
-          io.on("connection", (socket) => {
-            socket.emit("2");
-          });
-
-          const [_, firstPacket] = await runHandshake(port);
-
-          assertEquals(firstPacket, '42["1"]\x1e42["2"]');
-
-          done();
-        },
-      );
-    });
+        done();
+      },
+    );
   });
 });


### PR DESCRIPTION

This PR fixes four confirmed protocol and metadata bugs across the Socket.IO and
Engine.IO layers:

- removes stale namespace state after a namespace disconnect so reconnecting to
  the same namespace works on the same Engine.IO session
- rejects `transport=websocket` requests for polling sessions unless the request
  is a real WebSocket upgrade
- applies `editResponseHeaders` to CORS preflight responses as documented
- derives `secure` and `xdomain` from the actual request URL and `Origin` header
  instead of hardcoded values

## How This Solves The Issues

### Namespace reconnect

`Client` stored namespace sockets by namespace name but removed them by socket
id. This PR makes removal use `socket.nsp.name`, so `41/custom,` actually clears
the namespace entry and a later `40/custom,` can reconnect cleanly.

### Transport mismatch validation

Engine.IO now distinguishes a valid polling-to-websocket upgrade request from an
ordinary HTTP request that merely carries `transport=websocket`. Non-upgrade
mismatches are rejected with the existing `TRANSPORT_MISMATCH` error instead of
hanging on the polling transport.

### Preflight response headers

`editResponseHeaders` now runs before the early `OPTIONS` return path, so custom
response headers are applied consistently to preflight and non-preflight
requests.

### Handshake metadata

Handshake metadata is now derived from the request URL and `Origin` header:

- `secure` is `true` for `https:` requests
- `xdomain` is only `true` when `Origin` differs from the request origin

## Tests

Added regression coverage for:

- namespace reconnect after `41/custom,`
- polling session transport mismatch with `transport=websocket`
- `editResponseHeaders` on `OPTIONS` preflight requests
- handshake `secure` and `xdomain` metadata derivation

Full test suite result on branch `fix/repro-report-and-protocol-bugs`:

```text
ok | 25 passed (176 steps) | 0 failed | 0 ignored (1 step)
```

Command used:

```bash
/home/fuad/.deno/bin/deno test -A
```